### PR TITLE
(bugfix) fix username parsing with spaces in it

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,7 +135,12 @@ client.on("message", async message => {
     var contentleng = message.content.split(' ').length;
     //if message contains a second parameter
     if (contentleng > 1) {
-      var username_ = message.content.split(' ')[1].toLowerCase();
+      var str_list = message.content.split(' ')
+      str_list.shift()
+      if (str_list[str_list.length-1] == "here"){
+        str_list.splice(-1,1)
+      }
+      var username_ = str_list.join(" ").toLowerCase();
       //fetch user in guild by username
       var userlist = await message.guild.members.fetch({});
       for (var uobj of userlist) {

--- a/main.js
+++ b/main.js
@@ -130,41 +130,46 @@ client.on("message", async message => {
 
   if (!message.content.startsWith(prefix)) return;
   //initialize voice channel
+  var contentleng = message.content.split(' ').length;
   if (message.content.startsWith(`${prefix}link`)) {
     data.textChannel = message.channel;
-    var contentleng = message.content.split(' ').length;
     //if message contains a second parameter
     if (contentleng > 1) {
-      var str_list = message.content.split(' ')
-      str_list.shift()
-      if (str_list[str_list.length-1] == "here"){
-        str_list.splice(-1,1)
-      }
-      var username_ = str_list.join(" ").toLowerCase();
+      var username_ = message.split(' ').slice(1).join(' ');
       //fetch user in guild by username
+      var user_ = null;
       var userlist = await message.guild.members.fetch({});
       for (var uobj of userlist) {
         var u = uobj[1];
-        if (u.displayName.toLowerCase() == username_) {
-          var voicechann = u.voice.channel;
-          if (contentleng > 2) {
-            if (message.content.split(' ')[2] == 'here') {
-              voicechann = currentuser.voice;
-              if (voicechann == null) {
-                data.textChannel.send(ERROR.errorcode_3(u.displayName));
-                return;
-              }
-            }
-          } else {
-            if (voicechann == null) {
-              data.textChannel.send(ERROR.errorcode_3(u.displayName));
-              return;
-            }
+        if (u.displayName.toLowerCase().startsWith(username_)) {
+          if(user_ != null){
+            data.textChannel.send(ERROR.errorcode_6(username_));
+            return;
           }
-
-          linkUser(data, u, voicechann);
+          user_ = u;
+          
           return;
         }
+      }
+      if(user_==null){
+        data.textChannel.send(ERROR.errorcode_2(username_));
+      }else{
+          var voicechann = user_.voice.channel;
+          
+          var curusr_voicechann = currentuser.voice.channel;
+          if (voicechann == null) {
+            data.textChannel.send(ERROR.errorcode_3(u.displayName));
+            return;
+          }
+          if (curusr_voicechann == null) {
+            data.textChannel.send(ERROR.errorcode_4(currentuser.displayName));
+            return;
+          }
+          if(curusr_voicechann.id != voicechann.id){
+            data.textChannel.send(ERROR.errorcode_7());
+            return;
+          }
+          linkUser(data, u, voicechann);
       }
       data.textChannel.send(ERROR.errorcode_2(username_));
       return;


### PR DESCRIPTION
This PR fixes the following scenario:

Lets say you have a friend with a displayname like "Morning Glory Enjoyer".
So to link the bot with him, you do:
```
!link Morning Glory Enjoyer here
```

This will give you the following error message:

```
[ERROR]: A user by the query term Morning could not be found in your channel
```

My approach takes the entire array, removes the first and last (if the last item is "here") item and passes the entire array as username.
This effectively fixes the username parsing.

Im not a node dev, so theres probably a better / cooler way to do this